### PR TITLE
Feat:Insert multiple <li> into <ul>

### DIFF
--- a/03/index.js
+++ b/03/index.js
@@ -4,7 +4,7 @@ const fragment = document.createDocumentFragment();
 
 const contents = [
   { href: 'a1.html', src: '/img/bookmark.png', text: 'a1' },
-  { href: 'a2.html', src: '/img/bookmark.png', text: 'a2' }
+  { href: 'a2.html', src: '/img/message.png', text: 'a2' }
 ];
 
 for(var i = 0; i < contents.length; ++i){

--- a/03/index.js
+++ b/03/index.js
@@ -7,7 +7,7 @@ const contents = [
   { href: 'a2.html', src: '/img/message.png', text: 'a2' }
 ];
 
-for(var i = 0; i < contents.length; ++i){
+for(let i = 0; i < contents.length; ++i){
   const image = document.createElement('img');
   const anchor = document.createElement('a');
   const li = document.createElement('li');

--- a/03/index.js
+++ b/03/index.js
@@ -1,30 +1,29 @@
-//get:ID='js-lists'
+
 const ul = document.getElementById('js-lists');
-//create <li>
-const li = document.createElement('li');
+const fragment = document.createDocumentFragment();
 
-//create <img>
-const image = document.createElement('img');
-//add src attribute
-image.src = 'bookmark.png';
-//add alt attribute
-image.alt = 'ブックマーク';
+const contents = [
+  { href: 'a1.html', src: '/img/bookmark.png', text: 'a1' },
+  { href: 'a2.html', src: '/img/bookmark.png', text: 'a2' }
+];
 
-//create <a>
-const link = document.createElement('a');
-//add href attribute
-link.href = '1.html';
+for(var i = 0; i < contents.length; ++i){
+  const image = document.createElement('img');
+  const anchor = document.createElement('a');
+  const li = document.createElement('li');
 
-//add img to <a>
-link.appendChild(image);
+  const content = contents[i];
 
-//create text 
-const text = 'これです';
-//Add text after the last child element within the <a> element
-link.insertAdjacentHTML("beforeend",text);
+  image.src = content.src;
+  anchor.href = content.href;
 
-//add link to li
-li.appendChild(link);
+  li
+  .appendChild(anchor)
+  .appendChild(image);
 
-//add li to ul
-ul.appendChild(li);
+  anchor.insertAdjacentHTML('beforeend',content.text);
+
+  fragment.appendChild(li);
+}
+
+ul.appendChild(fragment);

--- a/03/index.js
+++ b/03/index.js
@@ -7,7 +7,7 @@ const contents = [
   { href: 'a2.html', src: '/img/message.png', text: 'a2' }
 ];
 
-for(let i = 0; i < contents.length; ++i){
+for(let i = 0; i < contents.length; i++){
   const image = document.createElement('img');
   const anchor = document.createElement('a');
   const li = document.createElement('li');


### PR DESCRIPTION
# [Issue No.3](https://github.com/kenmori/handsonFrontend/blob/0087a459ae7e84af59ead2d97d9c6b5153481e69/work/markup/1.md#3)

## StackBlitz
[StackBlitz](https://stackblitz.com/~/github.com/sunacodesu/frontend-handson)
↓プレビュー
[StackBlitz](https://stackblitz.com/edit/web-platform-53uway?file=03%2Findex.js)

## Concerns and areas to focus on

I have prepared an array, but the src value is "/img/bookmark.png".
I was wondering what they have in common.

I thought it would be better to store common values ​​in separate variables, but it would be better to prioritize the "src attribute" which does not change over having a common value (which may change). I chose this description because I thought it might be better.
Sorry if the explanation is difficult to understand.

配列を用意していますが、srcの値は「/img/bookmark.png」。
共通している点が気になりました。

共通の値については、別で変数に格納した方がよいかと考えましたが、（変動する可能性のある）値が共通であることよりも、変動しない「src属性」を優先する方が、ベターなのではないかと考え、今回の記述を選びました。

## 今回実装した仕様

I inserted multiple `<li>` containing images and links using a for statement inside `<ul>`